### PR TITLE
新規投稿時郵便番号→住所変換機能の修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
         <div class="row">
           <div class="col-md-3">
       <!--検索用部分テンプレートに変更-->
-            <%= link_to new_post_path,class:"nav-link text-dark" do%>
+            <%= link_to new_post_path,class:"nav-link text-dark", data: {"turbolinks" => false} do%>
               <i class="fa-solid fa-camera"></i> 新規投稿
             <% end %>
           </div>

--- a/app/views/public/users/show.html.erb
+++ b/app/views/public/users/show.html.erb
@@ -22,6 +22,7 @@
             <h3>投稿一覧</h3>
             <div>
              <table class="table" style="margin-top: -50px;">
+               <%#上記ではfooter重複未解決%>
 
                <thead>
                  <tr>


### PR DESCRIPTION
-郵便番号→住所変換がリロード後にしかできなかった問題に対してturbolinksの無効化を実施
-参考URL
https://qiita.com/ginger-yell/items/740818f484bfbc1edb4d